### PR TITLE
DataPacket Deserialization

### DIFF
--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -64,7 +64,7 @@ class Block:
         raw = self.prev_hash.encode() + self.payload + self.timestamp.encode()
         raw += self.nonce.to_bytes(NONCE_LENGTH)
         return sha256(raw).hexdigest()
-    
+
     def set_stop_mining(self, value: bool) -> None:
         """Safely set  stop_mining flag."""
         self.stop_mining = value
@@ -170,6 +170,12 @@ class BlockChain:
         if len(self) != len(other):
             return False
         return all([self[i] == other[i] for i in range(len(self))])
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, BlockChain):
+            msg = f"Cannot compare blockchain with {other.__class__}"
+            raise TypeError(msg)
+        return len(self) < len(other)
 
     # ----- end of magic methods ----- #
 

--- a/lib/packet.py
+++ b/lib/packet.py
@@ -42,7 +42,7 @@ class DataPacket:
         """Support c.key direct access."""
         if key in self.data:
             return self.data[key]
-        return super().__getattr__(key)
+        raise AttributeError(f"Attribute {key} not found.")
 
     def as_dict(self):
         return self.data

--- a/lib/packet.py
+++ b/lib/packet.py
@@ -38,6 +38,12 @@ class DataPacket:
         """Support c[i]."""
         return self.data[key]
 
+    def __getattr__(self, key: str) -> Any:
+        """Support c.key direct access."""
+        if key in self.data:
+            return self.data[key]
+        return super().__getattr__(key)
+
     def as_dict(self):
         return self.data
 

--- a/lib/packet.py
+++ b/lib/packet.py
@@ -1,3 +1,4 @@
+import json
 from enum import IntEnum
 from time import time
 from typing import Any
@@ -44,8 +45,11 @@ class DataPacket:
             return self.data[key]
         raise AttributeError(f"Attribute {key} not found.")
 
-    def as_dict(self):
+    def as_dict(self) -> dict:
         return self.data
+
+    def as_bytes(self) -> bytes:
+        return json.dumps(self.data).encode()
 
     @classmethod
     def from_dict(cls, data: dict) -> "DataPacket":

--- a/test/test_packet.py
+++ b/test/test_packet.py
@@ -31,6 +31,20 @@ class TestDataPacketCommon(unittest.TestCase):
         # different time stamp
         self.assertNotEqual(p1, p2)
 
+    def test_getattr(self):
+        p1 = DataPacket()
+        p1.data["type"] = "hello"
+        self.assertEqual(p1.type, "hello")
+
+    def test_getattr_super(self):
+        p1 = DataPacket()
+        self.assertTrue(p1.__class__)
+
+    def test_getattr_super_err(self):
+        p1 = DataPacket()
+        with self.assertRaises(AttributeError):
+            _ = p1.nosuchattr
+
 
 class TestAnnouncementPacket(unittest.TestCase):
 
@@ -89,6 +103,11 @@ class TestDeserialize(unittest.TestCase):
         with self.assertRaises(ValueError):
             DataPacket.from_dict(bad)
 
+    def test_deserialize_null(self):
+        bad = {"type": 0}
+        with self.assertRaises(ValueError):
+            DataPacket.from_dict(bad)
+
     def test_deserialize_ann_req(self):
         c = BlockChain()
         c.grow(b"hello")
@@ -96,8 +115,8 @@ class TestDeserialize(unittest.TestCase):
         ser = p.as_dict()
         deser = DataPacket.from_dict(ser)
         self.assertEqual(p, deser)
-        self.assertEqual(c, BlockChain.from_list(deser["chain"]))
-        self.assertEqual(("localhost", 1000), deser["tracker"])
+        self.assertEqual(c, BlockChain.from_list(deser.chain))
+        self.assertEqual(("localhost", 1000), deser.tracker)
 
     def test_deserialize_peer_list_req(self):
         p = PeerListRequestPacket()
@@ -112,15 +131,15 @@ class TestDeserialize(unittest.TestCase):
         ser = p.as_dict()
         deser = DataPacket.from_dict(ser)
         self.assertEqual(p, deser)
-        self.assertEqual(tr, deser["tracker"])
-        self.assertEqual(pl, deser["peers"])
+        self.assertEqual(tr, deser.tracker)
+        self.assertEqual(pl, deser.peers)
 
     def test_deserialize_redirect(self):
         p = RedirectPacket(("localhost", 1000))
         ser = p.as_dict()
         deser = DataPacket.from_dict(ser)
         self.assertEqual(p, deser)
-        self.assertEqual(("localhost", 1000), deser["tracker"])
+        self.assertEqual(("localhost", 1000), deser.tracker)
 
     def test_deserialize_block_update(self):
         c = BlockChain()
@@ -129,4 +148,4 @@ class TestDeserialize(unittest.TestCase):
         ser = p.as_dict()
         deser = DataPacket.from_dict(ser)
         self.assertEqual(p, deser)
-        self.assertEqual(c, BlockChain.from_list(deser["chain"]))
+        self.assertEqual(c, BlockChain.from_list(deser.chain))

--- a/test/test_packet.py
+++ b/test/test_packet.py
@@ -1,9 +1,11 @@
 import unittest
+from time import sleep
 
 from lib.blockchain import BlockChain
 from lib.packet import (
     AnnouncementPacket,
     BlockUpdatePacket,
+    DataPacket,
     PacketType,
     PeerListPacket,
     PeerListRequestPacket,
@@ -14,6 +16,22 @@ from lib.utils import setup_logger
 log = setup_logger(1, name=__name__)
 
 
+class TestDataPacketCommon(unittest.TestCase):
+
+    def test_eq(self):
+        p1 = DataPacket()
+        sleep(0.01)
+        p2 = DataPacket()
+        # different time stamp
+        self.assertNotEqual(p1, p2)
+
+    def test_eq_only_on_datapackets(self):
+        p1 = DataPacket()
+        p2 = {}
+        # different time stamp
+        self.assertNotEqual(p1, p2)
+
+
 class TestAnnouncementPacket(unittest.TestCase):
 
     def test_creating(self):
@@ -21,7 +39,7 @@ class TestAnnouncementPacket(unittest.TestCase):
         p = AnnouncementPacket(c, ("localhost", 1000))
         res = p.as_dict()
         self.assertEqual(res["type"], PacketType.ANNOUNCEMENT)
-        self.assertEqual(res["chain"], c)
+        self.assertEqual(res["chain"], c.as_list())
         self.assertEqual(res["tracker"], ("localhost", 1000))
 
 
@@ -61,4 +79,54 @@ class TestBlockUpdatePacket(unittest.TestCase):
         p = BlockUpdatePacket(c)
         res = p.as_dict()
         self.assertEqual(res["type"], PacketType.BLOCK_UPDATE)
-        self.assertEqual(res["chain"], c)
+        self.assertEqual(res["chain"], c.as_list())
+
+
+class TestDeserialize(unittest.TestCase):
+
+    def test_deserialize_undef(self):
+        bad = {"typpppp": 1}
+        with self.assertRaises(ValueError):
+            DataPacket.from_dict(bad)
+
+    def test_deserialize_ann_req(self):
+        c = BlockChain()
+        c.grow(b"hello")
+        p = AnnouncementPacket(c, ("localhost", 1000))
+        ser = p.as_dict()
+        deser = DataPacket.from_dict(ser)
+        self.assertEqual(p, deser)
+        self.assertEqual(c, BlockChain.from_list(deser["chain"]))
+        self.assertEqual(("localhost", 1000), deser["tracker"])
+
+    def test_deserialize_peer_list_req(self):
+        p = PeerListRequestPacket()
+        ser = p.as_dict()
+        deser = DataPacket.from_dict(ser)
+        self.assertEqual(p, deser)
+
+    def test_deserialize_peer_list(self):
+        tr = ("localhost", 1000)
+        pl = [("127.0.0.1", 5000), ("127.0.0.1", 5001)]
+        p = PeerListPacket(tr, pl)
+        ser = p.as_dict()
+        deser = DataPacket.from_dict(ser)
+        self.assertEqual(p, deser)
+        self.assertEqual(tr, deser["tracker"])
+        self.assertEqual(pl, deser["peers"])
+
+    def test_deserialize_redirect(self):
+        p = RedirectPacket(("localhost", 1000))
+        ser = p.as_dict()
+        deser = DataPacket.from_dict(ser)
+        self.assertEqual(p, deser)
+        self.assertEqual(("localhost", 1000), deser["tracker"])
+
+    def test_deserialize_block_update(self):
+        c = BlockChain()
+        c.grow(b"hello")
+        p = BlockUpdatePacket(c)
+        ser = p.as_dict()
+        deser = DataPacket.from_dict(ser)
+        self.assertEqual(p, deser)
+        self.assertEqual(c, BlockChain.from_list(deser["chain"]))


### PR DESCRIPTION
1. Adopt BlockChain's serialization in the data packet
2. Add deserialization to DataPacket
3. Allow dot access to DataPacket fields.
4. Unit tests